### PR TITLE
Small comments

### DIFF
--- a/shimmer-android/src/main/java/com/facebook/shimmer/ShimmerFrameLayout.java
+++ b/shimmer-android/src/main/java/com/facebook/shimmer/ShimmerFrameLayout.java
@@ -743,20 +743,22 @@ public class ShimmerFrameLayout extends FrameLayout {
     try {
       return createBitmapAndGcIfNecessary(width, height);
     } catch (OutOfMemoryError e) {
-      String logMessage = "ShimmerFrameLayout failed to create working bitmap";
-      StringBuilder logMessageStringBuilder = new StringBuilder(logMessage);
-      logMessageStringBuilder.append(" (width = ");
-      logMessageStringBuilder.append(width);
-      logMessageStringBuilder.append(", height = ");
-      logMessageStringBuilder.append(height);
-      logMessageStringBuilder.append(")\n\n");
-      for (StackTraceElement stackTraceElement :
-          Thread.currentThread().getStackTrace()) {
-        logMessageStringBuilder.append(stackTraceElement.toString());
-        logMessageStringBuilder.append("\n");
+      if (BuildConfig.DEBUG) {
+        String logMessage = "ShimmerFrameLayout failed to create working bitmap";
+        StringBuilder logMessageStringBuilder = new StringBuilder(logMessage);
+        logMessageStringBuilder.append(" (width = ");
+        logMessageStringBuilder.append(width);
+        logMessageStringBuilder.append(", height = ");
+        logMessageStringBuilder.append(height);
+        logMessageStringBuilder.append(")\n\n");
+        for (StackTraceElement stackTraceElement :
+                Thread.currentThread().getStackTrace()) {
+            logMessageStringBuilder.append(stackTraceElement.toString());
+            logMessageStringBuilder.append("\n");
+        }
+        logMessage = logMessageStringBuilder.toString();
+        Log.d(TAG, logMessage);
       }
-      logMessage = logMessageStringBuilder.toString();
-      Log.d(TAG, logMessage);
     }
     return null;
   }

--- a/shimmer-android/src/main/java/com/facebook/shimmer/ShimmerFrameLayout.java
+++ b/shimmer-android/src/main/java/com/facebook/shimmer/ShimmerFrameLayout.java
@@ -682,7 +682,7 @@ public class ShimmerFrameLayout extends FrameLayout {
   protected void onDetachedFromWindow() {
     stopShimmerAnimation();
     if (mGlobalLayoutListener != null) {
-      getViewTreeObserver().removeGlobalOnLayoutListener(mGlobalLayoutListener);
+      getViewTreeObserver().removeOnGlobalLayoutListener(mGlobalLayoutListener);
       mGlobalLayoutListener = null;
     }
     super.onDetachedFromWindow();


### PR DESCRIPTION
Hi,
I basically did this PR to give you some feedback on this library. This approach is generally looking very good, it's pretty nice to affect this behaviour to any kind of view.
Now a few comments:
- I've placed the `Log.d` statement behind the flag `BuildConfig.DEBUG` as it's not advised to log anything on release
- I've replaced the deprecated `removeGlobalOnLayoutListener` by `removeOnGlobalLayoutListener` as the min target is 16 (by the way, any reason for that?)
- I'm not quite sure about the motivations behind the method `createBitmapAndGcIfNecessary()`. It looks a bit brutal to force a garbage collection for an animation. I understand the use of an explicit garbage collection on pre-honeycomb because bitmaps were not stored on the VM and they were not triggering garbage collection. But you should be safe without the try catch.
- It looks like bad practice to use a try/finally in a view constructor (and actually Jake Wharton tweeted about that earlier). If something wrong happens then, it should just crash otherwise there will be bad behaviour and it will be impossible to spot what's going wrong.

Anyway, good job. Keep up the good work!
