### PR TITLE
Draw ShimmerDrawable mDrawRect at correct position

### DIFF
--- a/shimmer/src/main/java/com/facebook/shimmer/ShimmerDrawable.java
+++ b/shimmer/src/main/java/com/facebook/shimmer/ShimmerDrawable.java
@@ -118,8 +118,8 @@ public final class ShimmerDrawable extends Drawable {
     }
 
     final int saveCount = canvas.save();
-    canvas.translate(dx, dy);
     canvas.rotate(mShimmer.tilt, width / 2f, height / 2f);
+    canvas.translate(dx, dy);
     canvas.drawRect(mDrawRect, mShimmerPaint);
     canvas.restoreToCount(saveCount);
   }


### PR DESCRIPTION
After translation, rotation pivot (width/2, height/2) doesn't correspond to the center of mDrawRect, which leads to an incorrect mDrawRect position.
Perform translation after rotation to fix the issue.

re #59