### PR TITLE
Add support for start delay in shimmer library.

### DIFF
--- a/shimmer/src/main/java/com/facebook/shimmer/Shimmer.java
+++ b/shimmer/src/main/java/com/facebook/shimmer/Shimmer.java
@@ -78,6 +78,7 @@ public class Shimmer {
   int repeatMode = ValueAnimator.RESTART;
   long animationDuration = 1000L;
   long repeatDelay;
+  long startDelay;
 
   Shimmer() {}
 
@@ -179,7 +180,11 @@ public class Shimmer {
         setRepeatMode(
             a.getInt(R.styleable.ShimmerFrameLayout_shimmer_repeat_mode, mShimmer.repeatMode));
       }
-
+      if (a.hasValue(R.styleable.ShimmerFrameLayout_shimmer_start_delay)) {
+        setStartDelay(
+            a.getInt(
+                R.styleable.ShimmerFrameLayout_shimmer_start_delay, (int) mShimmer.startDelay));
+      }
       if (a.hasValue(R.styleable.ShimmerFrameLayout_shimmer_direction)) {
         int direction =
             a.getInt(R.styleable.ShimmerFrameLayout_shimmer_direction, mShimmer.direction);
@@ -260,6 +265,7 @@ public class Shimmer {
       setRepeatCount(other.repeatCount);
       setRepeatMode(other.repeatMode);
       setRepeatDelay(other.repeatDelay);
+      setStartDelay(other.startDelay);
       setDuration(other.animationDuration);
       mShimmer.baseColor = other.baseColor;
       mShimmer.highlightColor = other.highlightColor;
@@ -396,6 +402,15 @@ public class Shimmer {
         throw new IllegalArgumentException("Given a negative repeat delay: " + millis);
       }
       mShimmer.repeatDelay = millis;
+      return getThis();
+    }
+
+    /** Sets how long to wait for starting the shimmering animation. */
+    public T setStartDelay(long millis) {
+      if (millis < 0) {
+        throw new IllegalArgumentException("Given a negative start delay: " + millis);
+      }
+      mShimmer.startDelay = millis;
       return getThis();
     }
 

--- a/shimmer/src/main/java/com/facebook/shimmer/ShimmerDrawable.java
+++ b/shimmer/src/main/java/com/facebook/shimmer/ShimmerDrawable.java
@@ -163,6 +163,7 @@ public final class ShimmerDrawable extends Drawable {
     mValueAnimator =
         ValueAnimator.ofFloat(0f, 1f + (float) (mShimmer.repeatDelay / mShimmer.animationDuration));
     mValueAnimator.setRepeatMode(mShimmer.repeatMode);
+    mValueAnimator.setStartDelay(mShimmer.startDelay);
     mValueAnimator.setRepeatCount(mShimmer.repeatCount);
     mValueAnimator.setDuration(mShimmer.animationDuration + mShimmer.repeatDelay);
     mValueAnimator.addUpdateListener(mUpdateListener);

--- a/shimmer/src/main/res/values/attrs.xml
+++ b/shimmer/src/main/res/values/attrs.xml
@@ -15,6 +15,7 @@
       <enum name="restart" value="1"/>
       <enum name="reverse" value="2"/>
     </attr>
+    <attr name="shimmer_start_delay" format="integer"/>
     <attr name="shimmer_direction" format="enum">
       <enum name="left_to_right" value="0"/>
       <enum name="top_to_bottom" value="1"/>


### PR DESCRIPTION
Shimmer library right now only supports repeat delay but not start delay while ValueAnimator supports both. This is useful to stagger the shimmer animations in case there are multiple ShimmerFrameLayouts in a view.