### PR TITLE
docs: adding ELI5 video to the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,14 @@
     indicator that was originally developed for
     <a href="https://facebook.com/home" target="_blank">Facebook Home</a>.
     </p>
+    <div align="center">
+      <h3>Watch Introductory Video</h3>
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/iFL7guEYLko" 
+      title="Explain Like I'm 5: Shimmer for Android" frameBorder="0" 
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+      allowFullScreen ></iframe>
+    </div>
+    <br/>
     <p>
     Shimmer for Android is implemented as a layout, which means that you can simply
     nest any view inside a <code>ShimmerFrameLayout</code> tag, and call to start


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan 
![image](https://user-images.githubusercontent.com/12485205/155195988-52ff19bd-dece-4251-a110-aef7f36cb81a.png)
